### PR TITLE
change: .venv -> <name of venv>

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,22 @@ git clone https://github.com/nfoert/circles
 Navigate to it using and create a virtual enviroment
 ```
 cd circles
-python -m venv .venv
+python -m venv <name of venv>
 ```
 Activate the venv using the command for your system and install the necessary packages
 (for Windows):
 ```
-source ./.venv/Scripts/activate
+source ./<name of venv>/Scripts/activate
 pip install -r requirements.txt
 ```
 (for Mac OS):
 ```
-source ./.venv/bin/activate
+source ./<name of venv>/bin/activate
 pip install -r requirements.txt
 ```
 (for Linux):
 ```
-source ./.venv/bin/activate
+source ./<name of venv>/bin/activate
 pip install -r requirements.txt
 ```
 <br>
@@ -116,7 +116,7 @@ On my production server I also have to run `python manage.py collectstatic` to g
 Here's a brief explanation on how to contribute if you're new here.
 1. Press the `Fork Repo` button. This creates a copy of the repo for you to edit.
 2. Run the `git clone https://<username>/<name of forked repo>` command on your computer to download the files for you to edit
-3. Create a virtual enviroment with `python -m venv .venv` and activate it with the command for your system.
+3. Create a virtual enviroment with `python -m venv <name of venv>` and activate it with the command for your system.
 4. Install the required packages with `pip install -r requirements.txt`
 5. Move to the directory using `cd circles`
 6. Migrate changes using `python manage.py makemigrations && python manage.py migrate`


### PR DESCRIPTION
As discussed in #7 .
Changed in documentation from .venv for `<name of venv>`.
To avoid confusion for potential contributors who use other names for venv.